### PR TITLE
feature: write last updated as ISO date

### DIFF
--- a/packages/e2e/test/packageExtensionLastUpdatedFromGitCommit.test.ts
+++ b/packages/e2e/test/packageExtensionLastUpdatedFromGitCommit.test.ts
@@ -28,7 +28,7 @@ test('packageExtension adds lastUpdated from git commit to extension.json', asyn
     cwd: extensionDir,
   })
   await execa('git', ['add', 'extension.json'], { cwd: extensionDir })
-  const commitDate = '2024-01-15T10:30:00'
+  const commitDate = '2024-01-15T10:30:00+05:30'
   await execa('git', ['commit', '-m', 'Initial commit'], {
     cwd: extensionDir,
     env: {
@@ -49,10 +49,6 @@ test('packageExtension adds lastUpdated from git commit to extension.json', asyn
   )
   expect(updatedExtensionJson.name).toBe('test-extension')
   expect(updatedExtensionJson.description).toBe('Test extension')
-  expect(typeof updatedExtensionJson.lastUpdated).toBe('number')
-  expect(updatedExtensionJson.lastUpdated).toBeGreaterThan(0)
-  const expectedTimestamp = Math.floor(
-    new Date('2024-01-15T10:30:00').getTime() / 1000,
-  )
-  expect(updatedExtensionJson.lastUpdated).toBe(expectedTimestamp)
+  expect(typeof updatedExtensionJson.lastUpdated).toBe('string')
+  expect(updatedExtensionJson.lastUpdated).toBe('2024-01-15T05:00:00.000Z')
 })

--- a/packages/package-extension/src/parts/GetLastUpdatedDate/GetLastUpdatedDate.ts
+++ b/packages/package-extension/src/parts/GetLastUpdatedDate/GetLastUpdatedDate.ts
@@ -1,9 +1,17 @@
 import { execa } from 'execa'
 
-const getGitCommitDateFromGit = async (cwd: string): Promise<number | null> => {
+const toIsoString = (timestamp: number): string | null => {
+  const date = new Date(timestamp)
+  if (Number.isNaN(date.getTime())) {
+    return null
+  }
+  return date.toISOString()
+}
+
+const getGitCommitDateFromGit = async (cwd: string): Promise<string | null> => {
   const { exitCode, stdout } = await execa(
     'git',
-    ['log', '-1', '--format=%cd', '--date=format:%Y%m%d%H%M%S'],
+    ['log', '-1', '--format=%cI'],
     {
       cwd,
       reject: false,
@@ -15,27 +23,18 @@ const getGitCommitDateFromGit = async (cwd: string): Promise<number | null> => {
   if (!stdout || stdout.trim() === '') {
     return null
   }
-  const dateString = stdout.trim()
-  // Parse YYYYMMDDHHMMSS format
-  const year = Number.parseInt(dateString.slice(0, 4), 10)
-  const month = Number.parseInt(dateString.slice(4, 6), 10) - 1 // Month is 0-indexed
-  const day = Number.parseInt(dateString.slice(6, 8), 10)
-  const hour = Number.parseInt(dateString.slice(8, 10), 10)
-  const minute = Number.parseInt(dateString.slice(10, 12), 10)
-  const second = Number.parseInt(dateString.slice(12, 14), 10)
-  const date = new Date(year, month, day, hour, minute, second)
-  return Math.floor(date.getTime() / 1000) // Convert to unix timestamp (seconds)
+  return toIsoString(Date.parse(stdout.trim()))
 }
 
 export const getLastUpdatedDate = async (
   env: NodeJS.ProcessEnv = process.env,
   cwd: string = process.cwd(),
-): Promise<number | null> => {
+): Promise<string | null> => {
   const { GIT_COMMIT_DATE } = env
   if (GIT_COMMIT_DATE) {
-    const timestamp = Number.parseInt(GIT_COMMIT_DATE, 10)
-    if (!Number.isNaN(timestamp)) {
-      return timestamp
+    const timestampInSeconds = Number(GIT_COMMIT_DATE)
+    if (Number.isFinite(timestampInSeconds)) {
+      return toIsoString(timestampInSeconds * 1000)
     }
   }
   return getGitCommitDateFromGit(cwd)

--- a/packages/package-extension/test/GetLastUpdatedDate.test.ts
+++ b/packages/package-extension/test/GetLastUpdatedDate.test.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@jest/globals'
+import { mkdtemp, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getLastUpdatedDate } from '../src/parts/GetLastUpdatedDate/GetLastUpdatedDate.ts'
+
+test('getLastUpdatedDate converts an environment timestamp to a UTC ISO string', async () => {
+  const env = {
+    GIT_COMMIT_DATE: '1705294800',
+  }
+  expect(await getLastUpdatedDate(env)).toBe('2024-01-15T05:00:00.000Z')
+})
+
+test('getLastUpdatedDate returns null outside a git repository', async () => {
+  const cwd = await mkdtemp(join(tmpdir(), 'package-extension-'))
+  try {
+    expect(await getLastUpdatedDate({}, cwd)).toBe(null)
+  } finally {
+    await rm(cwd, { force: true, recursive: true })
+  }
+})


### PR DESCRIPTION
Store extension lastUpdated metadata as a human-readable UTC ISO 8601 string while preserving the commit instant.